### PR TITLE
use standard logging, similar to henne49/dbus-opendtu#173

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You have to edit `config.ini`. Please note the comments there as explanation!
 
 | Config value        | Explanation   |
 |-------------------- | ------------- |
-| Logging | set loglevel for `current.log` respectivly `/var/log/dbus-d0-smartmeter/current.log`. Possible values among others are `DEBUG`, `INFO`, `WARING` |
+| Logging | set loglevel for `/var/log/dbus-d0-smartmeter/current`. Possible values among others are `DEBUG`, `INFO`, `WARING` |
 | SignOfLiveLog | if >0, interval in minutes to give stats (= number of received correct SML-data) |
 | CustomName | user-friendly name for the gridmeter within the Venus web-GUI |
 | TimeoutInterval | if no valid data is received within this millisencods-interval, the DBUS-service-property Connected will be set to 0 |
@@ -71,7 +71,7 @@ You do not have to modify serial-starter.rules beause `service/run` stops the co
 
 If you have good luck, just run `install.sh` and the gridmeter appears within the Venus-GUI.
 
-`current.log` will look like this:
+`/var/log/dbus-d0-smartmeter/current` will look like this:
 
 ````
 2023-05-31 19:13:16,534 root INFO Starting...

--- a/dbus-d0-smartmeter.py
+++ b/dbus-d0-smartmeter.py
@@ -2,7 +2,6 @@
  
 # import normal packages
 import logging
-from logging.handlers import RotatingFileHandler
 import sys
 import os
 import platform
@@ -424,12 +423,7 @@ def main():
   logging.basicConfig(      format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S',
                             #level=logging.DEBUG,
-                            level=config['DEFAULT']['Logging'],
-                            handlers=[
-                                #logging.FileHandler("%s/current.log" % (os.path.dirname(os.path.realpath(__file__)))),
-                                RotatingFileHandler('%s/current.log' % (os.path.dirname(os.path.realpath(__file__))), maxBytes=1000000, backupCount=3),
-                                logging.StreamHandler()
-                            ])
+                            level=config['DEFAULT']['Logging'])
  
   try:
       logging.info("Starting...");

--- a/service/log/run
+++ b/service/log/run
@@ -1,6 +1,3 @@
 #!/bin/sh
-#set -x
-SCRIPT_DIR=$( realpath $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) )
-SERVICE_NAME=$( basename $( realpath $SCRIPT_DIR/../.. ) )
 exec 2>&1
-exec multilog t s25000 n4 /var/log/$SERVICE_NAME
+exec multilog t s25000 n4 /var/log/dbus-d0-smartmeter


### PR DESCRIPTION
else errors from 'run' script are not logged